### PR TITLE
Skip serializing null metadata_log

### DIFF
--- a/icelake/src/types/on_disk/table_metadata.rs
+++ b/icelake/src/types/on_disk/table_metadata.rs
@@ -40,14 +40,19 @@ pub(crate) struct TableMetadata {
     partition_specs: Vec<PartitionSpec>,
     default_spec_id: i32,
     last_partition_id: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
     properties: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     current_snapshot_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     snapshots: Option<Vec<Snapshot>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     snapshot_log: Option<Vec<SnapshotLog>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     metadata_log: Option<Vec<MetadataLog>>,
     sort_orders: Vec<SortOrder>,
     default_sort_order_id: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
     refs: Option<HashMap<String, SnapshotReference>>,
 }
 

--- a/icelake/src/types/on_disk/table_metadata.rs
+++ b/icelake/src/types/on_disk/table_metadata.rs
@@ -44,6 +44,7 @@ pub(crate) struct TableMetadata {
     current_snapshot_id: Option<i64>,
     snapshots: Option<Vec<Snapshot>>,
     snapshot_log: Option<Vec<SnapshotLog>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     metadata_log: Option<Vec<MetadataLog>>,
     sort_orders: Vec<SortOrder>,
     default_sort_order_id: i32,


### PR DESCRIPTION
When metadata_log is None icelake will render a null value in the metadata json, breaking the polars.scan_iceberg fuction

What happens is the following:
- v1.metdata.json rendered by iceberg code during table creation omits metadata_log
- v2.metadata.json is rendered by icelake which renders null

This patch ensures metadata_log is only rendered if it is not None.